### PR TITLE
Refactoring

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ab9ea51f5e406f0634e9d0cbf0a3089",
+    "content-hash": "b6f82fd33b53081d87a162d3d0b5a9c0",
     "packages": [],
     "packages-dev": [
         {
@@ -68,16 +68,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
                 "shasum": ""
             },
             "require": {
@@ -118,9 +118,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-06-25T14:52:30+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -235,16 +235,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.1",
+            "version": "10.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "884a0da7f9f46f28b2cb69134217fd810b793974"
+                "reference": "db1497ec8dd382e82c962f7abbe0320e4882ee4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/884a0da7f9f46f28b2cb69134217fd810b793974",
-                "reference": "884a0da7f9f46f28b2cb69134217fd810b793974",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/db1497ec8dd382e82c962f7abbe0320e4882ee4e",
+                "reference": "db1497ec8dd382e82c962f7abbe0320e4882ee4e",
                 "shasum": ""
             },
             "require": {
@@ -301,7 +301,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.1"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.2"
             },
             "funding": [
                 {
@@ -309,20 +309,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-17T12:15:40+00:00"
+            "time": "2023-05-22T09:04:27+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd"
+                "reference": "5647d65443818959172645e7ed999217360654b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
-                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/5647d65443818959172645e7ed999217360654b6",
+                "reference": "5647d65443818959172645e7ed999217360654b6",
                 "shasum": ""
             },
             "require": {
@@ -361,7 +361,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.2"
             },
             "funding": [
                 {
@@ -369,7 +370,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-10T16:53:14+00:00"
+            "time": "2023-05-07T09:13:23+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -554,16 +555,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.1.2",
+            "version": "10.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6f0cd95be71add539f8fd2be25b2a4a29789000b"
+                "reference": "35c8cac1734ede2ae354a6644f7088356ff5b08e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6f0cd95be71add539f8fd2be25b2a4a29789000b",
-                "reference": "6f0cd95be71add539f8fd2be25b2a4a29789000b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/35c8cac1734ede2ae354a6644f7088356ff5b08e",
+                "reference": "35c8cac1734ede2ae354a6644f7088356ff5b08e",
                 "shasum": ""
             },
             "require": {
@@ -603,7 +604,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -635,7 +636,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.1.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.3"
             },
             "funding": [
                 {
@@ -651,7 +652,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-22T07:38:19+00:00"
+            "time": "2023-06-30T06:17:38+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1677,7 +1678,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1",
+        "php": "^8.1",
         "ext-pdo": "*"
     },
     "platform-dev": [],

--- a/src/DsnBuilder.php
+++ b/src/DsnBuilder.php
@@ -4,19 +4,52 @@ namespace Tnapf\Driver;
 
 class DsnBuilder
 {
-    public const PREFIX_MYSQL = "mysql";
-    public const PREFIX_POSTGRES = "pgsql";
-    public const PREFIX_CUBRID = "cubrid";
-    public const PREFIX_ORACLE = "oci";
-    public const PREFIX_SQLITE = "sqlite";
-    public const PREFIX_ODBC = "odbc";
-    public const PREFIX_IBM = "ibm";
-    public const PREFIX_MS_SQL = "sqlsrv";
-    public const PREFIX_MS_SQL_LIB = "sybase";
-    public const PREFIX_INFORMIX = "informix";
-    public const PREFIX_FIREBIRD = "firebird";
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_MYSQL = DsnPrefix::MYSQL;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_POSTGRES = DsnPrefix::POSTGRES;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_CUBRID = DsnPrefix::CUBRID;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_ORACLE = DsnPrefix::ORACLE;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_SQLITE = DsnPrefix::SQLITE;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_ODBC = DsnPrefix::ODBC;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_IBM = DsnPrefix::IBM;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_MS_SQL = DsnPrefix::MS_SQL;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_MS_SQL_LIB = DsnPrefix::MS_SQL_LIB;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_INFORMIX = DsnPrefix::INFORMIX;
+    /**
+     * @deprecated use {@link DsnPrefix} cases instead.
+     */
+    public const PREFIX_FIREBIRD = DsnPrefix::FIREBIRD;
 
-    protected string $prefix = self::PREFIX_MYSQL;
+    protected DsnPrefix $prefix = DsnPrefix::MYSQL;
     protected array $config = [];
 
     public static function createMySQLDsn(
@@ -39,12 +72,16 @@ class DsnBuilder
     ): self {
         $dsn = new self();
         $dsn->config = compact('host', 'port', 'dbname', 'sslMode');
-        $dsn->prefix = self::PREFIX_POSTGRES;
+        $dsn->prefix = DsnPrefix::POSTGRES;
         return $dsn;
     }
 
-    public function setPrefix(string $prefix): self
+    public function setPrefix(string|DsnPrefix $prefix): self
     {
+        if (is_string($prefix)) {
+            $prefix = DsnPrefix::from($prefix);
+        }
+
         $this->prefix = $prefix;
         return $this;
     }
@@ -60,9 +97,13 @@ class DsnBuilder
         return $this->config[$prop] ?? null;
     }
 
-    public static function buildDsn(string $prefix, array $props): string
+    public static function buildDsn(string|DsnPrefix $prefix, array $props): string
     {
-        $dsn = "{$prefix}:";
+        if (is_string($prefix)) {
+            $prefix = DsnPrefix::from($prefix);
+        }
+
+        $dsn = "{$prefix->value}:";
         foreach ($props as $name => $value) {
             if ($value === null) {
                 continue;
@@ -76,7 +117,7 @@ class DsnBuilder
 
     public function __toString(): string
     {
-        return $this->buildDsn($this->prefix, $this->config);
+        return static::buildDsn($this->prefix->value, $this->config);
     }
 
     public static function new(): self

--- a/src/DsnPrefix.php
+++ b/src/DsnPrefix.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tnapf\Driver;
+
+enum DsnPrefix: string
+{
+    case MYSQL = "mysql";
+    case POSTGRES = "pgsql";
+    case CUBRID = "cubrid";
+    case ORACLE = "oci";
+    case SQLITE = "sqlite";
+    case ODBC = "odbc";
+    case IBM = "ibm";
+    case MS_SQL = "sqlsrv";
+    case MS_SQL_LIB = "sybase";
+    case INFORMIX = "informix";
+    case FIREBIRD = "firebird";
+}

--- a/src/PDODriver.php
+++ b/src/PDODriver.php
@@ -8,9 +8,6 @@ use Tnapf\Driver\Exceptions\DriverException;
 use Tnapf\Driver\Interfaces\DriverInterface;
 use Tnapf\Driver\Interfaces\PreparedQueryInterface;
 use Tnapf\Driver\Interfaces\QueryInterface;
-use Tnapf\Driver\PreparedQuery;
-use Tnapf\Driver\Query;
-use Tnapf\Driver\Interfaces\QueryResponseInterface;
 
 class PDODriver implements DriverInterface
 {
@@ -39,6 +36,9 @@ class PDODriver implements DriverInterface
         return new PreparedQuery($query, $this);
     }
 
+    /**
+     * @throws DriverException
+     */
     public function connect(): void
     {
         if ($this->isConnected()) {

--- a/src/PreparedQuery.php
+++ b/src/PreparedQuery.php
@@ -2,6 +2,8 @@
 
 namespace Tnapf\Driver;
 
+use Exception;
+use PDOException;
 use PDOStatement;
 use Tnapf\Driver\Exceptions\QueryException;
 use Tnapf\Driver\Interfaces\DriverInterface;
@@ -19,9 +21,16 @@ class PreparedQuery implements PreparedQueryInterface
         $this->stmt = $this->driver->pdo->prepare($this->query);
     }
 
+    /**
+     * @throws QueryException
+     */
     public function bindValue(string $name, mixed $value): void
     {
-        $result = $this->stmt->bindValue($name, $value);
+        try {
+            $result = $this->stmt->bindValue($name, $value);
+        } catch (PDOException $e) {
+            throw new QueryException($this, $e->getMessage(), $e->getCode(), $e);
+        }
 
         if ($result === false) {
             [$sqlState, $errorCode, $errorMessage] = $this->stmt->errorInfo();
@@ -33,6 +42,9 @@ class PreparedQuery implements PreparedQueryInterface
         }
     }
 
+    /**
+     * @throws QueryException
+     */
     public function bindValues(array $values): void
     {
         foreach ($values as $name => $value) {
@@ -40,9 +52,16 @@ class PreparedQuery implements PreparedQueryInterface
         }
     }
 
+    /**
+     * @throws QueryException
+     */
     public function execute(): QueryResponseInterface
     {
-        $result = $this->stmt->execute();
+        try {
+            $result = $this->stmt->execute();
+        } catch (PDOException $e) {
+            throw new QueryException($this, $e->getMessage(), $e->getCode(), $e);
+        }
 
         if ($result === false) {
             [$sqlState, $errorCode, $errorMessage] = $this->stmt->errorInfo();

--- a/src/Query.php
+++ b/src/Query.php
@@ -2,6 +2,8 @@
 
 namespace Tnapf\Driver;
 
+use Exception;
+use PDOException;
 use Tnapf\Driver\Exceptions\QueryException;
 use Tnapf\Driver\Interfaces\DriverInterface;
 use Tnapf\Driver\Interfaces\QueryInterface;
@@ -15,9 +17,16 @@ class Query implements QueryInterface
     ) {
     }
 
+    /**
+     * @throws QueryException
+     */
     public function execute(): QueryResponseInterface
     {
-        $result = $this->driver->pdo->query($this->query);
+        try {
+            $result = $this->driver->pdo->query($this->query);
+        } catch (PDOException $e) {
+            throw new QueryException($this, $e->getMessage(), $e->getCode(), $e);
+        }
 
         if ($result === false) {
             [$sqlState, $errorCode, $errorMessage] = $this->driver->pdo->errorInfo();

--- a/src/Row.php
+++ b/src/Row.php
@@ -6,6 +6,11 @@ use Tnapf\Driver\Interfaces\RowInterface;
 
 class Row implements RowInterface
 {
+    public static function create(array $row): Row
+    {
+        return new static($row);
+    }
+
     public function __construct(
         protected readonly array $row
     ) {
@@ -13,18 +18,12 @@ class Row implements RowInterface
 
     public function jsonSerialize(): array
     {
-        return $this->row;
+        return $this->getColumns();
     }
 
     public function getColumns(): array
     {
-        $array = [];
-
-        foreach ($this->row as $key => $value) {
-            $array[$key] = $value;
-        }
-
-        return $array;
+        return $this->row;
     }
 
     public function getColumn(string $columnName): mixed

--- a/tests/DsnBuilderTest.php
+++ b/tests/DsnBuilderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Tnapf\Driver;
 
 use PHPUnit\Framework\TestCase;
 use Tnapf\Driver\DsnBuilder;
+use Tnapf\Driver\DsnPrefix;
 
 class DsnBuilderTest extends TestCase
 {


### PR DESCRIPTION
- Implemented lazy fetching for `QueryResponse`.
- Added PDOException wraps for `Query` and `PreparedQuery` in case if `PDODriver` was created with EXCEPTION PDO attribute.
- Removed overhead in `Row::getColumns()` method. Added static named constructor `Row::create()` for convenient callback reference.
- Implemented enumeration for DSN prefixes. Deprecated `DsnBuilder` constants.
- Added missing `@throws`.
